### PR TITLE
Allow overriding of default text color

### DIFF
--- a/blue/_theme_vars.scss
+++ b/blue/_theme_vars.scss
@@ -29,7 +29,7 @@ $Theme-color-yellowOrange: #fab23c;
 
 // styleguide:ignore:start
 // Color Usage
-$Theme-palette-text-body-default: $Theme-color-poloBlue;
+$Theme-palette-text-body-default: $Theme-color-poloBlue !default;
 
 // Spacing
 $Theme-spacing-default: 50px;


### PR DESCRIPTION
Since the blog has an entirely different color for text and headings, it makes
sense to allow override of this variable (and possibly others in the future,
depending on our needs)
