### PR TITLE
Allow override of font-sizes map

### DIFF
--- a/blue/_theme_vars.scss
+++ b/blue/_theme_vars.scss
@@ -64,6 +64,7 @@ $Theme-nav-height: 80px;
 //
 // $family - Defines the font-family to be fetched
 // $size - Defines the size of the font to be fetched
+// $font-sizes - (Optional) Defines an alternative map of font sizes to use
 //
 // Styleguide 3.1
 
@@ -156,14 +157,14 @@ $Theme-font-sizes: (
   )
 );
 
-@mixin font-properties($family, $size: 'base') {
+@mixin font-properties($family, $size: 'base', $font-sizes: $Theme-font-sizes) {
   font-family: map-get($Theme-font-families, $family);
-  font-size: map-get(map-get(map-get(map-get($Theme-font-sizes, 'mobile'), $family), $size), 'font-size');
-  line-height: map-get(map-get(map-get(map-get($Theme-font-sizes, 'mobile'), $family), $size), 'line-height');
+  font-size: map-get(map-get(map-get(map-get($font-sizes, 'mobile'), $family), $size), 'font-size');
+  line-height: map-get(map-get(map-get(map-get($font-sizes, 'mobile'), $family), $size), 'line-height');
 
   @include media('>=tablet') {
-    font-size: map-get(map-get(map-get(map-get($Theme-font-sizes, 'desktop'), $family), $size), 'font-size');
-    line-height: map-get(map-get(map-get(map-get($Theme-font-sizes, 'desktop'), $family), $size), 'line-height');
+    font-size: map-get(map-get(map-get(map-get($font-sizes, 'desktop'), $family), $size), 'font-size');
+    line-height: map-get(map-get(map-get(map-get($font-sizes, 'desktop'), $family), $size), 'line-height');
   }
 }
 


### PR DESCRIPTION
Since the blog has a couple of different font sizes, which are not declared in
the original map, I need a way to use font-properties easily with those extra
fonts.
