### PR TITLE
Only allow cell alignment when not in tablet mode

### DIFF
--- a/stylesheets/components/_grid_cell.scss
+++ b/stylesheets/components/_grid_cell.scss
@@ -27,12 +27,14 @@
   padding: 0 $Theme-spacing-default;
 }
 
-.GridCell.GridCell--alignCenter {
-  justify-content: center;
-}
+@include media('>=tablet') {
+  .GridCell.GridCell--alignCenter {
+    justify-content: center;
+  }
 
-.GridCell.GridCell--alignRight {
-  justify-content: flex-end;
+  .GridCell.GridCell--alignRight {
+    justify-content: flex-end;
+  }
 }
 
 .GridCell-content {


### PR DESCRIPTION
There was an issue when the columns are in row (tablet mode). Since the
columns are limited to 565px some would align to the right when they
should be in a normal row.
