### PR TITLE
Remove margins top and bottom responsibility from the limited grid

### DIFF
--- a/stylesheets/components/_horizontal_grid.scss
+++ b/stylesheets/components/_horizontal_grid.scss
@@ -60,7 +60,8 @@
 
 .HorizontalGrid.HorizontalGrid--limited {
   max-width: $Theme-grid-maxWidth;
-  margin: 0 auto;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 .HorizontalGrid.HorizontalGrid--lightFrame {


### PR DESCRIPTION
There is no reason for this grid to control the margins top and bottom,
and with this change, it is more aligned with what the documentation says it
does.
