### PR TITLE
Grid changes for mobile

### DIFF
--- a/stylesheets/components/_grid_cell.scss
+++ b/stylesheets/components/_grid_cell.scss
@@ -24,10 +24,14 @@
   justify-content: flex-start;
 
   width: 100%;
-  padding: 0 $Theme-spacing-default;
+  padding: 0 $Theme-spacing-small;
 }
 
 @include media('>=tablet') {
+  .GridCell {
+    padding: 0 $Theme-spacing-default;
+  }
+
   .GridCell.GridCell--alignCenter {
     justify-content: center;
   }

--- a/stylesheets/components/_horizontal_grid.scss
+++ b/stylesheets/components/_horizontal_grid.scss
@@ -89,4 +89,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+
+  @include media('<=tablet') {
+    flex: initial;
+  }
 }


### PR DESCRIPTION
- Make gutter smaller on mobile devices.
- Don't force same size when grid is column.
