### PR TITLE
Fixes Navbar stuttering when scrolling in webkit

### DIFF
--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -52,6 +52,7 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
   background: transparent;
 
   transition: background-color 0.2s ease-in-out;
+  -webkit-transform: translateZ(0);
 }
 
 .Nav.Nav--topPositioned {


### PR DESCRIPTION
Apparently [this bug](https://bugs.webkit.org/show_bug.cgi?id=110478) affects
chrome's ability to determine if childs of fixed elements need to be
repainted. The workaround is to enable 3D transforms for the element
