### PR TITLE
Align right arrow icon with links

### DIFF
--- a/stylesheets/blue/_theme_vars.scss
+++ b/stylesheets/blue/_theme_vars.scss
@@ -193,9 +193,9 @@ $Theme-font-sizes: (
 // Styleguide 3.2
 @mixin right-arrow() {
   @include fa-icon();
-  @include font-properties(subvisual, small);
 
   font-size: 24px; // The icon is bigger than the text of the link
+  line-height: 28px;
   vertical-align: bottom;
 
   content: $fa-var-arrow-circle-right;


### PR DESCRIPTION
It is now more explicit that we are expecting the icon to be used only
with the subvisual small font, and we also take advantage of it setting
the line-height.

Fixes #30.
