### PR TITLE
New nav state

### DIFF
--- a/javascripts/blue/_nav_logo.es6
+++ b/javascripts/blue/_nav_logo.es6
@@ -11,7 +11,7 @@ $(function(){
     }
 
     function update($element) {
-      if ($element.hasClass('Nav--light')) {
+      if ($element.hasClass('Nav--light') || $element.hasClass('Nav--transparent')) {
         if ($element.hasClass('Nav--fixed')) {
           showColoredLogo($element);
         } else {

--- a/stylesheets/blue/components/_nav.scss
+++ b/stylesheets/blue/components/_nav.scss
@@ -6,6 +6,7 @@
 //
 // default - Nav with a transparent background
 // .Nav--light - Uses a lighter color in the nav links
+// .Nav--transparent - Uses white for all nav links, with transparency for all but the active one. To be used when there's one selected item, and a strong color or image background
 // .Nav--fixed - Affixes the nav to the top of the viewport and applies a background color for better readability
 // .Nav--topPositioned - Absolutely positions the nav to the top of its relative container
 // .Nav--hint - Affixes the nav to the top, adds a drop shadow to hint the user about the existence of the header
@@ -161,6 +162,24 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
   font-weight: $Theme-typography-fontWeight-bold;
   text-decoration: none;
   text-transform: uppercase;
+}
+
+.Nav.Nav--transparent:not(.Nav--fixed) {
+  .Nav-link {
+    color: $Theme-color-white;
+  }
+
+  .Nav-item:not(.is-selected) {
+    opacity: 0.6;
+  }
+
+  .Nav-item:hover,
+  .Nav-item.is-selected {
+    border-bottom-color: $Theme-color-white;
+    .Nav-link {
+      color: $Theme-color-white;
+    }
+  }
 }
 
 @include media('>=tablet') {


### PR DESCRIPTION
I didn't really know what to call this, so I'll take suggestions on that

According to @johnny1337 , this is suposed to be used on the main site, as well, but
the Zeplin designs are outdated. Basically, any page that has a strong color
or a background image on the hero shot should have this state (except the site
index, where there's no selected item in the nav)
