### PR TITLE
Change Sass import on blue.scss

### DIFF
--- a/stylesheets/blue.scss
+++ b/stylesheets/blue.scss
@@ -1,1 +1,1 @@
-@import './blue/index';
+@import 'blue/index';


### PR DESCRIPTION
Miiddleman does not work well with the ./ to reference a local
directory. Removing it works fine.
