### PR TITLE
Refactor Burger to use translate instead of top and 2px instead of 3

### DIFF
--- a/stylesheets/blue/components/_burger.scss
+++ b/stylesheets/blue/components/_burger.scss
@@ -18,8 +18,7 @@
   position: relative;
 
   width: 20px;
-  height: 22px;
-  margin: 50px auto;
+  height: 15px;
 
   cursor: pointer;
 
@@ -31,6 +30,7 @@
 
   .Burger-line {
     position: absolute;
+    top: 0;
     left: 0;
 
     display: block;
@@ -38,37 +38,34 @@
     height: 3px;
 
     background: $Theme-color-poloBlue;
-    border-radius: 3px;
+    border-radius: 2px;
     opacity: 1;
 
-    transform: rotate(0deg);
+    transform: rotate(0deg) translate(0px, 0px);
 
     transition: .25s ease-in-out;
   }
 
   .Burger-line:nth-child(1) {
-    top: 3px;
+    transform: translateY(0px);
 
     transform-origin: left center;
   }
 
   .Burger-line:nth-child(2) {
-    top: 9.5px;
+    transform: translateY(6px);
 
     transform-origin: left center;
   }
 
   .Burger-line:nth-child(3) {
-    top: 16px;
+    transform: translateY(12px);
 
     transform-origin: left center;
   }
 
   &.is-open .Burger-line:nth-child(1) {
-    top: 3px;
-    left: 3px;
-
-    transform: rotate(45deg);
+    transform: translate(3px, -1px) rotate(45deg);
   }
 
   &.is-open .Burger-line:nth-child(2) {
@@ -78,10 +75,7 @@
   }
 
   &.is-open .Burger-line:nth-child(3) {
-    top: 17px;
-    left: 3px;
-
-    transform: rotate(-45deg);
+    transform: translate(3px, 13px) rotate(-45deg);
   }
 }
 


### PR DESCRIPTION
I needed to change each line's height to 2px instead of 3 because with 3px I would end having to position the third line using decimal numbers, breaking on smaller screens.
