### PR TITLE
Fixes engagement link icon in IE

### DIFF
--- a/stylesheets/blue/components/_engagement_link.scss
+++ b/stylesheets/blue/components/_engagement_link.scss
@@ -36,9 +36,10 @@ $EngagementLink-arrow-white: 'blue/link-arrow-white.svg' !default;
     @include background-image($EngagementLink-arrow);
     content: '';
 
+    display: block;
     width: $EngagementLink-width-icon;
-    min-width: $EngagementLink-width-icon;
     height: $EngagementLink-width-icon;
+    min-width: $EngagementLink-width-icon;
     margin-right: $Theme-spacing-small;
 
     background-repeat: no-repeat;


### PR DESCRIPTION
The icon was not showing on IE (and the text was not properly aligned due to that). This is probably also a bug on their end.

The change doesn't seem to cause any changes in Chrome or Firefox