### PR TITLE
This seems to fix HorizontalGrid on all browsers

### DIFF
--- a/stylesheets/blue/components/_horizontal_grid.scss
+++ b/stylesheets/blue/components/_horizontal_grid.scss
@@ -184,7 +184,7 @@ $HorizontalGrid-border-width: 1px;
   flex-direction: column;
 
   @include media('<=tablet') {
-    flex: initial;
+    flex: none;
   }
 }
 


### PR DESCRIPTION
@azevedo-252 it seems using the 3 separate properties does not fix IE issues. It just doesn't seem to like it when `flex-basis: 0%`

But this PR seems to fix at least the HorizontalGrid component, which is already a lot.
If you're ok with this, we can at least get the main grid working and then start debugging other smaller flex issues