### PR TITLE
Corrects nav

### DIFF
--- a/stylesheets/blue/components/_nav.scss
+++ b/stylesheets/blue/components/_nav.scss
@@ -242,6 +242,10 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
     top: -$Theme-nav-height-desktop;
   }
 
+  .Nav-items {
+    max-height: $Theme-nav-height-desktop;
+  }
+
   .Nav-item:not(:first-child) {
     display: flex;
     align-items: center;
@@ -261,7 +265,7 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
     background-color: $Theme-color-white;
   }
 
-  .Nav-items {
+  .Nav-itemsWrapper {
     display: none;
   }
 


### PR DESCRIPTION
The nav was relying on `Nav-items` being a flex child, in order for it
not to overflow vertically. Now, we are limiting its height to the
correct one. This was the easiest way I found to correct this for all
resolutions.