### PR TITLE
Corrects nav on FF

### DIFF
--- a/stylesheets/blue/components/_nav.scss
+++ b/stylesheets/blue/components/_nav.scss
@@ -243,7 +243,7 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
   }
 
   .Nav-items {
-    max-height: $Theme-nav-height-desktop;
+    height: $Theme-nav-height-desktop;
   }
 
   .Nav-item:not(:first-child) {


### PR DESCRIPTION
For some reason FF was disregarding the max-height when painting the
border. Forcing the height seems to work on Chrome, FF and Safari.