### PR TITLE
Fixes high amount of repaints on scroll

### DIFF
--- a/stylesheets/blue/components/_nav_overlay.scss
+++ b/stylesheets/blue/components/_nav_overlay.scss
@@ -26,6 +26,7 @@ $NavOverlay-item-border-width: 50px;
 $NavOverlay-item-space: $Theme-spacing-default;
 
 .NavOverlay {
+  display: none;
   position: fixed;
   top: $Theme-nav-height-mobile;
   left: 0;


### PR DESCRIPTION
The `display: none` property was only being applied when closing the
menu. So the initial state was just hiding the element using `opacity: 0` causing multiple of repaints on scroll
Opening and closing the menu would fix the amount of repaints on
subsequent scrolls