### PR TITLE
Using fontfaceobserver to fix FOIT

### DIFF
--- a/stylesheets/blue/_theme_vars.scss
+++ b/stylesheets/blue/_theme_vars.scss
@@ -219,13 +219,20 @@ $Theme-font-sizes: (
 );
 
 @mixin font-properties-on-resolution($family, $size: 'base', $resolution: 'mobile', $font-sizes: $Theme-font-sizes) {
-  font-family: map-get($Theme-font-families, $family);
   font-size: map-get(map-get(map-get(map-get($font-sizes, $resolution), $family), $size), 'font-size');
   line-height: map-get(map-get(map-get(map-get($font-sizes, $resolution), $family), $size), 'line-height');
 }
 
 @mixin font-properties($family, $size: 'base', $font-sizes: $Theme-font-sizes) {
+  $family-list: map-get($Theme-font-families, $family);
+
   @include font-properties-on-resolution($family, $size, mobile, $font-sizes);
+
+  font-family: nth($family-list, length($family-list));
+
+  @at-root.wf-active & {
+    font-family: nth($family-list, 1);
+  }
 
   @include media('>=tablet') {
     @include font-properties-on-resolution($family, $size, desktop, $font-sizes);


### PR DESCRIPTION
This fixes the current FOIT problem. So, currently it will show text with a default browser font, and whenever the fonts are loaded (from typekit), the font-family will change as well.

The font loading must happen asynchronously in order to better improve the perceived speed. So either add the async attribute and/or move the loading to end of the body tag.

Resources:

* http://help.typekit.com/customer/portal/articles/6787-Font-events
* http://help.typekit.com/customer/portal/articles/6852-Controlling-the-Flash-of-Unstyled-Text-or-FOUT-using-Font-Events
