### PR TITLE
Support for animated NavLogo

### DIFF
--- a/javascripts/blue/_nav.es6
+++ b/javascripts/blue/_nav.es6
@@ -1,6 +1,7 @@
 $(function() {
   window.subvisual = window.subvisual || {};
-  window.subvisual.nav = (function() {
+  window.subvisual.nav = window.subvisual.nav || {};
+  window.subvisual.nav.bar = (function() {
     let $element = $('.Nav');
     let navLogo = window.subvisual.nav.logo;
     let navVisibility = window.subvisual.nav.visibility;

--- a/javascripts/blue/_nav_logo.es6
+++ b/javascripts/blue/_nav_logo.es6
@@ -2,29 +2,39 @@ $(function(){
   window.subvisual = window.subvisual || {};
   window.subvisual.nav = window.subvisual.nav || {};
   window.subvisual.nav.logo = (function() {
+
     function showMonoLogo($element) {
-      $element.find('.NavLogo').addClass('NavLogo--mono');
+      $element.removeClass('NavLogo--color').addClass('NavLogo--mono');
     }
 
-    function showColoredLogo($element) {
-      $element.find('.NavLogo').removeClass('NavLogo--mono');
+    function showColoredLogo($element, $navLogo) {
+      $element.removeClass('NavLogo--mono').addClass('NavLogo--color');
+    }
+
+    function backgroundIsLight($el) {
+      var
+        isOpen = $el.hasClass('is-open'),
+        isFixed = $el.hasClass('Nav--fixed'),
+        isTransparent = $el.hasClass('Nav--light') || $el.hasClass('Nav--transparent');
+
+      return isOpen || (isTransparent && isFixed) || (!isTransparent);
     }
 
     function update($element) {
-      if ($element.hasClass('Nav--light') || $element.hasClass('Nav--transparent')) {
-        if ($element.hasClass('Nav--fixed')) {
-          showColoredLogo($element);
-        } else {
-          showMonoLogo($element);
-        }
+      var $navLogo = $element.find('.NavLogo');
+
+      if (backgroundIsLight($element)) {
+        showColoredLogo($navLogo);
       } else {
-        showColoredLogo($element);
+        showMonoLogo($navLogo);
       }
     }
 
     function updateWithScroll(scrollState, $element) {
+      var $navLogo = $element.find('.NavLogo');
+
       if (scrollState.hasPassedTheElement($element.outerHeight())) {
-        showColoredLogo($element);
+        showColoredLogo($navLogo);
       } else {
         update($element);
       }

--- a/javascripts/blue/_nav_state.js
+++ b/javascripts/blue/_nav_state.js
@@ -17,6 +17,7 @@ $(function() {
     } else {
       closeOverlay();
     }
+    window.subvisual.nav.logo.update(nav);
   });
 
   // remove from accesibility tree when hidden.

--- a/javascripts/blue/_scroll.es6
+++ b/javascripts/blue/_scroll.es6
@@ -10,7 +10,7 @@ $(function() {
   setInterval(function() {
     if (didScroll) {
       currentScrollTop = $(document).scrollTop();
-      window.subvisual.nav.update(currentScrollTop, lastScrollTop);
+      window.subvisual.nav.bar.update(currentScrollTop, lastScrollTop);
       lastScrollTop = currentScrollTop;
 
       didScroll = false;

--- a/stylesheets/blue/components/_nav_logo.scss
+++ b/stylesheets/blue/components/_nav_logo.scss
@@ -11,52 +11,36 @@
 //
 // Styleguide 1.17
 
-$NavLogo-mobile-colored: '' !default;
-$NavLogo-mobile-mono: '' !default;
-$NavLogo-desktop-colored: '' !default;
-$NavLogo-desktop-mono: '' !default;
-
-$NavLogo-image: (
-  mobile: (
-    colored: $NavLogo-mobile-colored,
-    mono: $NavLogo-mobile-mono
-  ),
-  desktop: (
-    colored: $NavLogo-desktop-colored,
-    mono: $NavLogo-desktop-mono
-  )
-);
-
 .NavLogo {
-  width: 20px; // value extracted from the image
-  height: 30px; // value extracted from the image
-
-  // styleguide:ignore:start
-  background-image: url(map-get(map-get($NavLogo-image, 'mobile'), 'colored'));
-  // styleguide:ignore:end
-  background-repeat: no-repeat;
-  background-size: contain;
+  .NavLogo-svgColor {
+    display: block;
+  }
+  .NavLogo-svgMono {
+    display: none;
+  }
 }
 
 .NavLogo.NavLogo--mono {
-  // styleguide:ignore:start
-  background-image: url(map-get(map-get($NavLogo-image, 'mobile'), 'mono'));
-  // styleguide:ignore:end
+  .NavLogo-svgColor {
+    display: none;
+  }
+  .NavLogo-svgMono {
+    display: block;
+  }
 }
 
-@include media('>tablet') {
-  .NavLogo {
-    width: 202px; // value extracted from the image
-    height: 40px; // value extracted from the image
+.NavLogo {
 
-    // styleguide:ignore:start
-    background-image: url(map-get(map-get($NavLogo-image, 'desktop'), 'colored'));
-    // styleguide:ignore:end
-  }
+  width: 202px; // value extracted from the image
+  height: 40px; // value extracted from the image
+}
 
-  .NavLogo.NavLogo--mono {
-    // styleguide:ignore:start
-    background-image: url(map-get(map-get($NavLogo-image, 'desktop'), 'mono'));
-    // styleguide:ignore:end
+.NavLogo {
+  .NavLogo-name {
+    display: none;
+
+    @include media('>tablet') {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
This changes the way our nav Logo works, to support the new animated version

This branch is already live in the production version of the main site.
The nav is no longer using the images provided here, and I guess they can be deleted. The reason for that is that I now need to include the logo as a partial, and middleman doesn't allow inclusion of partials outside the `partials` directory

The logo partial is here: https://github.com/subvisual/subvisual.co/blob/master/source/partials/nav/_logo.html.erb
A similar change will be required in the other two apps before we update blue version on them

It includes two SVGs, a colored and a white one.
The CSS and JS relating to the Nav and NavLogo now only has to switch between the two, and no longer needs to set background-images

This also fixes a bug where pages such as /company/join-us, which displayed the white logo, would not switch to the colored one when opening the Overlay

@gabrielpoca can you take a look at this please?