### PR TITLE
Removes es6 extension from manifest

### DIFF
--- a/javascripts/blue.js
+++ b/javascripts/blue.js
@@ -1,6 +1,6 @@
-//= require ./blue/_scroll.es6
-//= require ./blue/_scroll_state.es6
-//= require ./blue/_nav_logo.es6
-//= require ./blue/_nav_visibility.es6
-//= require ./blue/_nav.es6
+//= require ./blue/_scroll
+//= require ./blue/_scroll_state
+//= require ./blue/_nav_logo
+//= require ./blue/_nav_visibility
+//= require ./blue/_nav
 //= require ./blue/_nav_state


### PR DESCRIPTION
Some of the files were being required with the full name & extension in the
all.js manifest

This does not work with Sprockets (at least with the version being used on the
blog), and it doesn't seem to be necessary in the main website either, so I'm
removing this to avoid having to monkey patch the blog's copy of this library