### PR TITLE
Add 'no underline' modifier to Nav component

### DIFF
--- a/stylesheets/blue/components/_nav.scss
+++ b/stylesheets/blue/components/_nav.scss
@@ -24,6 +24,9 @@
 //     <li class="Nav-item is-selected">
 //       <a class="Nav-link" href="#">Company</a>
 //     </li>
+//     <li class="Nav-itemNoUnderline">
+//       <a class="Nav-link" href="#">Apprenticeship</a>
+//     </li>
 //   </ul>
 // </nav>
 //
@@ -170,6 +173,17 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
       color: $Nav-item-color-hover;
     }
   }
+
+  @include media('>desktop') {
+    margin-left: $Theme-spacing-default;
+  }
+}
+
+.Nav-itemNoUnderline {
+  display: flex;
+  align-items: center;
+
+  margin-left: $Theme-spacing-small;
 
   @include media('>desktop') {
     margin-left: $Theme-spacing-default;


### PR DESCRIPTION
Why:

* Our Nav items need to be able to have no underlines when the item
itself doesn't look good

This change addresses the need by:

* Adding a new element to the component which simply lays out the item

<img width="1440" alt="screen shot 2016-03-11 at 12 16 30 pm" src="https://cloud.githubusercontent.com/assets/448574/13701960/280b8c3e-e783-11e5-9d47-750f624bd793.png">