### PR TITLE
Rename license in package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0"
   },
-  "license": "Mozilla Public License 2.0"
+  "license": "MPL-2.0"
 }


### PR DESCRIPTION
Why:
- Running `npm install` results in the following warning message being
  shown:
  `
  npm WARN EPACKAGEJSON blue license should be a valid SPDX license
  expression
  `

This change addresses the issue by:
- Refactoring the package manifest file to use the correct identifier
  for Mozilla Public License 2.0 according to [the SPDX License
  List](https://spdx.org/licenses/).
