### PR TITLE
Replace default body color

### DIFF
--- a/stylesheets/blue/_theme_vars.scss
+++ b/stylesheets/blue/_theme_vars.scss
@@ -46,7 +46,7 @@ $Theme-color-concrete: #f2f2f2;
 
 // styleguide:ignore:start
 // Color Usage
-$Theme-palette-text-body-default: $Theme-color-poloBlue !default;
+$Theme-palette-text-body-default: $Theme-color-limedSpruce !default;
 
 // Spacing
 $Theme-spacing-default: 50px;

--- a/stylesheets/blue/components/_heading.scss
+++ b/stylesheets/blue/components/_heading.scss
@@ -25,7 +25,7 @@
   @include font-properties(heading, base);
   width: 100%;
 
-  color: $Theme-color-horizon;
+  color: $Theme-color-limedSpruce;
 
   font-weight: $Theme-typography-fontWeight-bold;
 }


### PR DESCRIPTION
Why:

With the redesign we are changing the default text color.

This change addresses the need by:

* Change variable for the default color of body and heading.