### PR TITLE
Change the default text color to gunMetal

### DIFF
--- a/stylesheets/blue/_theme_vars.scss
+++ b/stylesheets/blue/_theme_vars.scss
@@ -21,9 +21,10 @@ $Theme-color-white: #fff;
 $Theme-color-yellowOrange: #fab23c;
 $Theme-color-silverChalice: #999;
 $Theme-color-concrete: #f2f2f2;
+$Theme-color-gunMetal: #41505b;
 
 // Color Usage
-$Theme-palette-text-body-default: $Theme-color-limedSpruce !default;
+$Theme-palette-text-body-default: $Theme-color-gunMetal !default;
 
 // Spacing
 $Theme-spacing-default: 40px;


### PR DESCRIPTION
Why:

With the redesign we are changing the default text color to grey instead
of blue.