### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Subvisual
+Copyright (c) 2015-2018 Subvisual
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Why:

* The copyright text in the license refers to 2015.

This issue change addresses the issue by:

* Updating the year in the license text.