### PR TITLE
Allow left side of Footer to shrink.

### DIFF
--- a/stylesheets/blue/components/_footer.scss
+++ b/stylesheets/blue/components/_footer.scss
@@ -16,6 +16,7 @@
 }
 
 .Footer-credits {
+  flex-shrink: 1;
   align-items: center;
 
   background-color: $Theme-color-limedSpruce;


### PR DESCRIPTION
In some browsers, the Footer is taking more space than the body because
there isn't enough space for the contents of the right side of the
footer. Because the left side has empty space, we can allow it to
shrink.

<img width="1410" alt="screen shot 2017-03-03 at 16 56 49" src="https://cloud.githubusercontent.com/assets/934580/23560488/8af567de-0032-11e7-9029-bf80ec1186bb.png">
