### PR TITLE
Add Mirrorconf 2017 theme stuff

### DIFF
--- a/stylesheets/blue/_theme_vars.scss
+++ b/stylesheets/blue/_theme_vars.scss
@@ -22,6 +22,9 @@ $Theme-color-yellowOrange: #fab23c;
 $Theme-color-gunMetal: #41505b;
 $Theme-color-blueyGrey: #849aaa;
 
+$mirrorconf-Theme-color-orange: #fd7d57;
+$mirrorconf-Theme-color-white: #fff;
+
 // Color Usage
 $Theme-palette-text-body-default: $Theme-color-blueyGrey !default;
 

--- a/stylesheets/blue/components/_button_secondary.scss
+++ b/stylesheets/blue/components/_button_secondary.scss
@@ -45,3 +45,15 @@
     color: rgba($Theme-color-limedSpruce, .8);
   }
 }
+
+.ButtonSecondary.ButtonSecondary--mirrorconf {
+  border-color: $mirrorconf-Theme-color-orange;
+
+  color: $mirrorconf-Theme-color-orange;
+
+  &:hover {
+    background-color: $mirrorconf-Theme-color-orange;
+    color: $mirrorconf-Theme-color-white;
+    box-shadow: 0 10px 20px 0 rgba($mirrorconf-Theme-color-orange, 0.25);
+  }
+}

--- a/stylesheets/blue/components/_heading.scss
+++ b/stylesheets/blue/components/_heading.scss
@@ -50,6 +50,10 @@
   color: $Theme-color-limedSpruce;
 }
 
+.Heading.Heading--mirrorconf {
+  color: $mirrorconf-Theme-color-orange;
+}
+
 .Heading-highlight {
   color: $Theme-color-brightTurquoise;
 }

--- a/stylesheets/blue/components/_text.scss
+++ b/stylesheets/blue/components/_text.scss
@@ -73,3 +73,7 @@
 .Text.Text--highlight {
   color: $Theme-color-brightTurquoise;
 }
+
+.Text.Text--mirrorconf {
+  color: $mirrorconf-Theme-color-white;
+}


### PR DESCRIPTION
Why:

* We're going to update the Subvisual's site community page and include
  a panel about MirrorConf 2017, for which we need to use the same
  colors that we used in https://2017.mirrorconf.com

This change addresses the need by:

* Adding the MirrorConf 2017 colors;
* Adding a modifier for MirrorConf in the secondary button, heading and
  text components.